### PR TITLE
Implement initial Python skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
-# Agent_Comapny
+# Agent Company
+
+This repository contains a minimal skeleton for an AI‑driven company. The code is
+written entirely in Python and includes the following modules:
+
+- `agent_company/agent.py` – a basic `AIWorker` class that wraps OpenAI's API.
+- `agent_company/mcp.py` – an example "MCP" server that coordinates a single
+  agent and forwards its output to Discord.
+- `agent_company/discord_client.py` – utilities for sending messages to a
+  Discord channel via a bot.
+- `agent_company/emailer.py` – a helper for sending emails via SMTP.
+- `agent_company/forms.py` – a stub for creating Google Forms.
+
+The implementation focuses on demonstrating how these components interact.
+すべてのチャット履歴は Discord のチャンネルにのみ残し、データベースには保存しません。
+Bot アカウントは一つだけ使用し、送信されるメッセージの先頭にエージェント名が付与されます。
+Environment 変数で Discord や OpenAI、SMTP などの設定を行います。
+
+Run the MCP example with:
+
+```bash
+python -m agent_company.mcp
+```
+
+This will invoke the agent using the `AGENT_PROMPT` environment variable and
+send the result to the configured Discord channel.
+
+エージェントから特定ユーザーへの DM を送る場合は `MCP.assign_task()` を利用してください。

--- a/agent_company/__init__.py
+++ b/agent_company/__init__.py
@@ -1,0 +1,1 @@
+"""Agent Company package."""

--- a/agent_company/agent.py
+++ b/agent_company/agent.py
@@ -1,0 +1,20 @@
+import os
+import openai
+
+
+class AIWorker:
+    """Base class for AI agents."""
+
+    def __init__(self, role: str):
+        self.role = role
+        self.model = os.getenv("OPENAI_MODEL", "gpt-3.5-turbo")
+        openai.api_key = os.getenv("OPENAI_API_KEY")
+
+    def run(self, prompt: str) -> str:
+        """Run the agent with the given prompt."""
+        response = openai.ChatCompletion.create(
+            model=self.model,
+            messages=[{"role": "system", "content": self.role},
+                      {"role": "user", "content": prompt}],
+        )
+        return response.choices[0].message["content"].strip()

--- a/agent_company/discord_client.py
+++ b/agent_company/discord_client.py
@@ -1,0 +1,59 @@
+import os
+import asyncio
+from typing import Optional
+
+import discord
+
+
+class DiscordLogger:
+    """Discord チャンネルや DM にメッセージを送るラッパー."""
+
+    def __init__(self, token: str, channel_id: int):
+        self.token = token
+        self.channel_id = channel_id
+        self.client = discord.Client(intents=discord.Intents.default())
+
+    async def _send(self, message: str):
+        await self.client.wait_until_ready()
+        channel = self.client.get_channel(self.channel_id)
+        if channel:
+            await channel.send(message)
+        await self.client.close()
+
+    def send_message(self, message: str):
+        async def runner():
+            await self._send(message)
+
+        self.client.loop.create_task(runner())
+        self.client.run(self.token)
+
+    async def _send_dm(self, user_id: int, message: str):
+        await self.client.wait_until_ready()
+        user = await self.client.fetch_user(user_id)
+        if user:
+            await user.send(message)
+        await self.client.close()
+
+    def send_dm(self, user_id: int, message: str):
+        async def runner():
+            await self._send_dm(user_id, message)
+
+        self.client.loop.create_task(runner())
+        self.client.run(self.token)
+
+
+def send_discord_message(message: str,
+                         token: Optional[str] = None,
+                         channel_id: Optional[int] = None):
+    token = token or os.getenv("DISCORD_BOT_TOKEN")
+    channel_id = channel_id or int(os.getenv("DISCORD_CHANNEL_ID", "0"))
+    logger = DiscordLogger(token, channel_id)
+    logger.send_message(message)
+
+
+def send_discord_dm(message: str,
+                    user_id: int,
+                    token: Optional[str] = None):
+    token = token or os.getenv("DISCORD_BOT_TOKEN")
+    logger = DiscordLogger(token, 0)
+    logger.send_dm(user_id, message)

--- a/agent_company/emailer.py
+++ b/agent_company/emailer.py
@@ -1,0 +1,41 @@
+import os
+import smtplib
+from email.message import EmailMessage
+from typing import Optional
+
+
+class Emailer:
+    def __init__(self,
+                 smtp_server: str,
+                 smtp_port: int,
+                 username: str,
+                 password: str):
+        self.smtp_server = smtp_server
+        self.smtp_port = smtp_port
+        self.username = username
+        self.password = password
+
+    def send_email(self, to_address: str, subject: str, body: str):
+        msg = EmailMessage()
+        msg["From"] = self.username
+        msg["To"] = to_address
+        msg["Subject"] = subject
+        msg.set_content(body)
+
+        with smtplib.SMTP_SSL(self.smtp_server, self.smtp_port) as server:
+            server.login(self.username, self.password)
+            server.send_message(msg)
+
+
+def send_mail(to: str, subject: str, body: str,
+              server: Optional[str] = None,
+              port: Optional[int] = None,
+              username: Optional[str] = None,
+              password: Optional[str] = None):
+    server = server or os.getenv("SMTP_SERVER")
+    port = int(port or os.getenv("SMTP_PORT", "465"))
+    username = username or os.getenv("SMTP_USERNAME")
+    password = password or os.getenv("SMTP_PASSWORD")
+
+    emailer = Emailer(server, port, username, password)
+    emailer.send_email(to, subject, body)

--- a/agent_company/forms.py
+++ b/agent_company/forms.py
@@ -1,0 +1,18 @@
+import os
+from typing import Any, Dict
+
+# Placeholder for Google Forms API integration
+
+
+def create_form(title: str, questions: Dict[str, str]) -> Any:
+    """Create a Google Form with given questions.
+
+    This function is a stub demonstrating where you'd call Google APIs.
+    """
+    # TODO: Implement Google Forms API integration
+    print(f"Creating form '{title}' with {len(questions)} questions.")
+    return {
+        "title": title,
+        "questions": questions,
+        "form_url": "https://example.com/form"  # placeholder
+    }

--- a/agent_company/mcp.py
+++ b/agent_company/mcp.py
@@ -1,0 +1,28 @@
+"""Minimal MCP server example."""
+import os
+from .agent import AIWorker
+from .discord_client import send_discord_message, send_discord_dm
+
+
+class MCP:
+    def __init__(self):
+        self.agent = AIWorker(role=os.getenv("AGENT_ROLE", "Default agent"))
+
+    def handle_task(self, prompt: str):
+        response = self.agent.run(prompt)
+        send_discord_message(f"[{self.agent.role}] {response}")
+        return response
+
+    def assign_task(self, user_id: int, task: str):
+        send_discord_dm(f"[{self.agent.role}] {task}", user_id)
+
+
+def main():
+    prompt = os.getenv("AGENT_PROMPT", "Say hello")
+    mcp = MCP()
+    result = mcp.handle_task(prompt)
+    print(result)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- create minimal `agent_company` package
- implement `AIWorker` base class and MCP server example
- add Discord, email, and Google Form helper modules
- update README with usage notes
- add DM support in Discord client
- prefix Discord messages with agent role

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68416f032ba08331aeaaa6627c51511d